### PR TITLE
Fix swagger generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
           <groupId>com.google.endpoints</groupId>
           <artifactId>endpoints-framework-tools</artifactId>
-          <version>2.0.9</version>
+          <version>2.1.1</version>
           <exclusions>
             <exclusion>
               <groupId>com.google.appengine</groupId>
@@ -113,7 +113,7 @@
         <dependency>
           <groupId>com.google.endpoints</groupId>
           <artifactId>endpoints-framework</artifactId>
-          <version>2.0.9</version>
+          <version>2.1.1</version>
           <exclusions>
             <exclusion>
               <groupId>com.google.appengine</groupId>

--- a/src/main/java/com/google/appengine/endpoints/EndpointsGetSwaggerDoc.java
+++ b/src/main/java/com/google/appengine/endpoints/EndpointsGetSwaggerDoc.java
@@ -6,6 +6,7 @@ package com.google.appengine.endpoints;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,12 +24,13 @@ public class EndpointsGetSwaggerDoc extends EndpointsMojo {
     ArrayList<String> arguments = new ArrayList<>();
     arguments.add(command);
     handleClassPath(arguments);
-    arguments.add("-o");
-    arguments.add(project.getBuild().getDirectory() + "/swagger.xml");
+    if (outputDirectory != null && !outputDirectory.isEmpty()) {
+      arguments.add("-o");
+      arguments.add(outputDirectory + "/WEB-INF/swagger.json");
+      new File(outputDirectory).mkdirs();
+    }
     arguments.add("-w");
-        String appDir = project.getBuild().getDirectory() + "/" + project.getBuild().getFinalName();
-
-    arguments.add(appDir);
+    arguments.add(outputDirectory);
     return arguments;
   }
 


### PR DESCRIPTION
- Align behavior with Discovery generation
- Use swagger.json instead of swagger.xml as generated file name
- Update Endpoints framework dependencies to latest